### PR TITLE
Added libraries for Debian 7.5

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,10 @@ apt-get install ntpdate --force-yes --yes
 #if ps aux | grep ntp | grep -qv grep; then 
 if [ -f /etc/init.d/ntp ]; then
 	/etc/init.d/ntp stop
+else 
+	# Needed for Kali Linux build on Raspberry Pi
+	apt-get install ntp
+	/etc/init.d/ntp stop
 fi
 echo "[+] Setting time with ntp"
 ntpdate ntp.ubuntu.com 

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ apt-get update
 
 # Packages
 echo "[+] Installing required packages..."
-apt-get install --force-yes --yes python-setuptools autossh python-psutil python2.7-dev libpcap0.8-dev python-sqlalchemy ppp tcpdump python-serial sqlite3 python-requests iw build-essential python-bluez python-flask python-gps python-dateutil python-dev
+apt-get install --force-yes --yes python-setuptools autossh python-psutil python2.7-dev libpcap0.8-dev python-sqlalchemy ppp tcpdump python-serial sqlite3 python-requests iw build-essential python-bluez python-flask python-gps python-dateutil python-dev libxml2-dev libxslt-dev
 
 # Python packages
 

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ apt-get update
 
 # Packages
 echo "[+] Installing required packages..."
-apt-get install --force-yes --yes python-setuptools autossh python-psutil python2.7-dev libpcap0.8-dev python-sqlalchemy ppp tcpdump python-serial sqlite3 python-requests iw build-essential python-bluez python-flask python-gps python-dateutil python-dev libxml2-dev libxslt-dev
+apt-get install --force-yes --yes python-setuptools autossh python-psutil python2.7-dev libpcap0.8-dev python-sqlalchemy ppp tcpdump python-serial sqlite3 python-requests iw build-essential python-bluez python-flask python-gps python-dateutil python-dev libxml2-dev libxslt-dev pyrit
 
 # Python packages
 

--- a/scripts/install_rpi.sh
+++ b/scripts/install_rpi.sh
@@ -8,7 +8,7 @@ dpkg-reconfigure openssh-server
 service ssh restart
 
 # Install git
-apt-get update && apt-get install ntp libxml2-dev libxslt-dev pyrit
+apt-get update && apt-get install -y ntp libxml2-dev libxslt-dev pyrit
 
 # Downlaod snoopy-ng from https://github.com/sensepost/snoopy-ng
 git clone https://github.com/sensepost/snoopy-ng.git

--- a/scripts/install_rpi.sh
+++ b/scripts/install_rpi.sh
@@ -8,7 +8,7 @@ dpkg-reconfigure openssh-server
 service ssh restart
 
 # Install git
-apt-get update && apt-get install git ntp libxml2-dev libxslt-dev pyrit
+apt-get update && apt-get install ntp libxml2-dev libxslt-dev pyrit
 
 # Downlaod snoopy-ng from https://github.com/sensepost/snoopy-ng
 git clone https://github.com/sensepost/snoopy-ng.git

--- a/scripts/install_rpi.sh
+++ b/scripts/install_rpi.sh
@@ -8,7 +8,7 @@ dpkg-reconfigure openssh-server
 service ssh restart
 
 # Install git
-apt-get update && apt-get install git ntp
+apt-get update && apt-get install git ntp libxml2-dev libxslt-dev pyrit
 
 # Downlaod snoopy-ng from https://github.com/sensepost/snoopy-ng
 git clone https://github.com/sensepost/snoopy-ng.git

--- a/scripts/install_rpi.sh
+++ b/scripts/install_rpi.sh
@@ -1,0 +1,17 @@
+#!/usr/bin
+
+# Install script for fresh Kali Linux (1.0.7) install on Raspberry Pi
+
+# Change SSH host keys
+rm /etc/ssh/ssh_host_*
+dpkg-reconfigure openssh-server
+service ssh restart
+
+# Install git
+apt-get update && apt-get install git ntp
+
+# Downlaod snoopy-ng from https://github.com/sensepost/snoopy-ng
+git clone https://github.com/sensepost/snoopy-ng.git
+
+# Install snoopy via insall.sh
+(cd snoopy-ng && bash ./install.sh)


### PR DESCRIPTION
Installation using install.sh fails on Debian 7.5 due to two missing libraries, libxml2-dev and libxslt-dev.