### PR TITLE
Added SSL support for the built-in web server used for syncing

### DIFF
--- a/plugins/server.py
+++ b/plugins/server.py
@@ -46,6 +46,8 @@ class Snoop(Thread):
         # Process arguments passed to module
         self.port = kwargs.get('port',9001)
         self.ip = kwargs.get('ip','0.0.0.0')
+        self.cert = kwargs.get('cert',None)
+        self.cert_key = kwargs.get('cert_key',None)
         self.db = kwargs.get('dbms',None)
 
         self.verb = kwargs.get('verbose', 0)
@@ -58,7 +60,7 @@ class Snoop(Thread):
 
     def run(self):
         logging.info("Running webserver on '%s:%s'" % (self.ip,self.port))
-        webserver.run_webserver(self.port,self.ip,self.db)
+        webserver.run_webserver(self.port,self.ip,self.cert,self.cert_key,self.db)
 
     def is_ready(self):
         #Perform any functions that must complete before plugin runs
@@ -72,6 +74,8 @@ class Snoop(Thread):
     def get_parameter_list():
         info = {"info" : "Runs a server - allowing local data to be synchronized remotely.",
                 "parameter_list" : [("port=<int>","The HTTP port to listen on."),
+                                    ("cert=<path>","The SSL certificate path (implies server will use HTTPS)."),
+                                    ("cert_key=<path>","The certificate key path (implies server will use HTTPS)."),
                                     ("xbee=<int>","The XBee PIN to listen on (see Pro version).")
                                     ]
                 }


### PR DESCRIPTION
Here is the little enhancement to the built-in Flask server that enables TLS 1.2 on the basis of an existing cert / key pair.

Usage like:

```bash
snoopy -v -m server:cert=[/path/to/cert.crt],cert_key=[/path/to/cert_key.key] --dbms=mysql://user:secret@localhost/snoopy_db
```

For syncing, drones should then use HTTPS:

```bash
snoopy --plugin example:x=1 --drone myDrone --key GWWVF --server https://<server_ip>:9001/ --verbose
```

I am also looking at the Apache option, but a little unsure around how to handle the plugins - i.e. if you want both server and Wigle to be running at the same time.