### PR TITLE
fixed a simple big that occured when running snoopy_auth -u

### DIFF
--- a/includes/auth_handler.py
+++ b/includes/auth_handler.py
@@ -177,7 +177,7 @@ if __name__ == "__main__":
             if args.users == "*":
                 args.users = None
             for pair in auth_.list_associations(user=args.users):
-                print "\t%s:%s" %(pair[0],pair[1])
+                print "\t%s:%s" %(pair['user'],pair['sensor'])
 
         if args.create:
             print "[+] Creating new Snoopy server sync account"

--- a/install.sh
+++ b/install.sh
@@ -60,10 +60,10 @@ echo "[+] Installing pyserial 2.6"
 pip install https://pypi.python.org/packages/source/p/pyserial/pyserial-2.6.tar.gz
 
 echo "[+] Downloading pylibpcap..."
-pip install http://switch.dl.sourceforge.net/project/pylibpcap/pylibpcap/0.6.4/pylibpcap-0.6.4.tar.gz
+pip install https://sourceforge.net/projects/pylibpcap/files/latest/download?source=files#egg=pylibpcap
 
 echo "[+] Downloading dpkt..."
-pip install http://dpkt.googlecode.com/files/dpkt-1.8.tar.gz
+pip install https://dpkt.googlecode.com/files/dpkt-1.8.tar.gz
 
 echo "[+] Installing patched version of scapy..."
 pip install ./setup/scapy-latest-snoopy_patch.tar.gz


### PR DESCRIPTION
when running 'snoopy_auth -u myusername', snoopy would return:

[+] User/drone associations:
Traceback (most recent call last):
  File "/usr/bin/snoopy_auth", line 180, in <module>
    print "\t%s:%s" %(pair[0],pair[1])
KeyError: 0

because 'pair' is a dictionary